### PR TITLE
Feat: 홈 및 카테고리별 상품 목록 조회와 카테고리 페이지 속한 필터 적용 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@radix-ui/themes": "^3.2.1",
+        "axios": "^1.11.0",
         "classnames": "^2.5.1",
         "lucide-react": "^0.525.0",
         "react": "^19.1.0",
@@ -2763,11 +2764,53 @@
         "node": ">=10"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/classnames": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/cookie": {
       "version": "1.0.2",
@@ -2785,11 +2828,79 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.8",
@@ -2848,6 +2959,42 @@
         }
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2863,6 +3010,39 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-nonce": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
@@ -2872,6 +3052,70 @@
         "node": ">=6"
       }
     },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/lucide-react": {
       "version": "0.525.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.525.0.tgz",
@@ -2879,6 +3123,36 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/nanoid": {
@@ -2948,6 +3222,12 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/radix-ui": {
       "version": "1.4.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@radix-ui/themes": "^3.2.1",
+    "axios": "^1.11.0",
     "classnames": "^2.5.1",
     "lucide-react": "^0.525.0",
     "react": "^19.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ import {
   ProductInquiry,
   SignUp,
 } from "./pages";
-import type { Message } from "./types";
+import type { Message } from "./types/types";
 
 export default function App() {
   const [isChatOpen, setIsChatOpen] = useState(false);

--- a/src/api/mainProducts.ts
+++ b/src/api/mainProducts.ts
@@ -1,0 +1,14 @@
+import { api } from "../lib/axios";
+import type { Product } from "../types/products";
+
+// 메인 페이지 신상품 조회
+export async function getNewProducts(): Promise<Product[]> {
+  const res = await api.get("/products/main");
+  return res.data.data.products as Product[];
+}
+
+// 메인 페이지 베스트 상품 조회
+export async function getBestProducts(): Promise<Product[]> {
+  const res = await api.get("/products/main"); // 주문 구현이후 수정
+  return res.data.data.products as Product[];
+}

--- a/src/api/products.ts
+++ b/src/api/products.ts
@@ -1,0 +1,29 @@
+import { api } from "../lib/axios";
+import type { ListProductsData, ListProductsParams } from "../types/products";
+
+// 3) 목록 조회 함수
+export async function listProducts(
+  params: ListProductsParams,
+): Promise<ListProductsData> {
+  const res = await api.get("/products", {
+    params,
+    // brand 배열을 &brand=a&brand=b 로 직렬화
+    paramsSerializer: {
+      serialize: (p: Record<string, unknown>) => {
+        const usp = new URLSearchParams();
+        Object.entries(p).forEach(([k, v]) => {
+          if (v === undefined || v === null || v === "") return;
+          if (Array.isArray(v)) {
+            v.forEach((item) => usp.append(k, String(item)));
+          } else {
+            usp.set(k, String(v));
+          }
+        });
+        return usp.toString();
+      },
+    },
+  });
+
+  // 서버 공통 포맷: { status, code, message, data }
+  return res.data.data as ListProductsData;
+}

--- a/src/components/molecules/CouponItem/CouponItem.tsx
+++ b/src/components/molecules/CouponItem/CouponItem.tsx
@@ -1,5 +1,5 @@
 import { CircleAlert, CircleCheck } from "lucide-react";
-import type { Coupon } from "../../../types";
+import type { Coupon } from "../../../types/types";
 import { Tag } from "../../atoms";
 import styles from "./CouponItem.module.css";
 

--- a/src/components/molecules/ProductCard/ProductCard.module.css
+++ b/src/components/molecules/ProductCard/ProductCard.module.css
@@ -1,4 +1,5 @@
 .card {
+  width: 12.75rem;
   display: flex;
   flex-direction: column;
   text-decoration: none;
@@ -12,7 +13,9 @@
   height: 12.75rem;
 }
 .image {
-  width: 100%;
+  width: 12.75rem;
+  height: 12.75rem;
+  object-fit: cover;
   border-radius: 0.5rem;
 }
 .cartBtn {

--- a/src/components/molecules/ProductCard/ProductCard.tsx
+++ b/src/components/molecules/ProductCard/ProductCard.tsx
@@ -1,7 +1,7 @@
 import { X } from "lucide-react";
 import { useState } from "react";
 import { useToast } from "../../../contexts/ToastContext";
-import type { Product } from "../../../types";
+import type { Product } from "../../../types/types";
 import { LikeButton, PriceTag, Tag } from "../../atoms";
 import styles from "./ProductCard.module.css";
 
@@ -44,7 +44,7 @@ export default function ProductCard({ product, deleteAble }: Props) {
     >
       <div className={styles.imageWrapper}>
         <img src={product.image} alt={product.name} className={styles.image} />
-        {product.discount && (
+        {product.discount !== undefined && product.discount > 0 && (
           <Tag
             discount={product.discount}
             variant="discount"

--- a/src/components/molecules/ProductCard/ProductCard.tsx
+++ b/src/components/molecules/ProductCard/ProductCard.tsx
@@ -1,7 +1,7 @@
 import { X } from "lucide-react";
 import { useState } from "react";
 import { useToast } from "../../../contexts/ToastContext";
-import type { Product } from "../../../types/types";
+import type { Product } from "../../../types/products";
 import { LikeButton, PriceTag, Tag } from "../../atoms";
 import styles from "./ProductCard.module.css";
 

--- a/src/components/molecules/ReviewItem/ReviewItem.tsx
+++ b/src/components/molecules/ReviewItem/ReviewItem.tsx
@@ -1,6 +1,6 @@
 import { Star } from "lucide-react";
 import { useLocation } from "react-router-dom";
-import type { Review } from "../../../types";
+import type { Review } from "../../../types/types";
 import { Button } from "../../atoms";
 import styles from "./ReviewItem.module.css";
 

--- a/src/components/molecules/ReviewableItem/ReviewableItem.tsx
+++ b/src/components/molecules/ReviewableItem/ReviewableItem.tsx
@@ -1,4 +1,4 @@
-import type { Review } from "../../../types";
+import type { Review } from "../../../types/types";
 import { Button } from "../../atoms";
 import styles from "./ReviewableItem.module.css";
 

--- a/src/components/organisms/ChatWidget/ChatWidget.tsx
+++ b/src/components/organisms/ChatWidget/ChatWidget.tsx
@@ -1,6 +1,6 @@
 import { MessagesSquare, Send, X } from "lucide-react";
 import { type FormEvent, useEffect, useRef } from "react";
-import type { Message } from "../../../types";
+import type { Message } from "../../../types/types";
 import { Input } from "../../atoms";
 import styles from "./ChatWidget.module.css";
 

--- a/src/components/organisms/CouponsSection/CouponsSection.tsx
+++ b/src/components/organisms/CouponsSection/CouponsSection.tsx
@@ -1,6 +1,6 @@
 import { Ticket } from "lucide-react";
 import { useState } from "react";
-import type { Coupon } from "../../../types";
+import type { Coupon } from "../../../types/types";
 import { Button } from "../../atoms";
 import { CouponItem, EmptyState } from "../../molecules";
 import styles from "./CouponsSection.module.css";

--- a/src/components/organisms/OrderHistorySection/OrderHistorySection.tsx
+++ b/src/components/organisms/OrderHistorySection/OrderHistorySection.tsx
@@ -1,6 +1,6 @@
 import { ShoppingBag } from "lucide-react";
 import { useState } from "react";
-import type { Order } from "../../../types";
+import type { Order } from "../../../types/types";
 import { Select, Tag } from "../../atoms";
 import { EmptyState, Table } from "../../molecules";
 import styles from "./OrderHistorySection.module.css";

--- a/src/components/organisms/ProductSection/ProductSection.tsx
+++ b/src/components/organisms/ProductSection/ProductSection.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { Product } from "../../../types";
+import type { Product } from "../../../types/products";
 import { SectionHeader, Select } from "../../atoms";
 import { ProductCard } from "../../molecules";
 import styles from "./ProductSection.module.css";
@@ -25,7 +25,9 @@ export default function ProductSection({
         (p) => selectedCategory === "all" || p.category === selectedCategory,
       );
 
+  // 원복: 내부에서 정렬 상태를 로컬로 관리
   const [selected, setSelected] = useState("추천순");
+  // (참고) option의 value와 맞추려면 "recommended"가 더 일관적입니다.
 
   return (
     <section className={styles.section}>

--- a/src/components/organisms/RecentViewSection/RecentViewSection.tsx
+++ b/src/components/organisms/RecentViewSection/RecentViewSection.tsx
@@ -1,5 +1,5 @@
 import { Eye, Trash } from "lucide-react";
-import type { Product } from "../../../types";
+import type { Product } from "../../../types/products";
 import { EmptyState, ProductCard } from "../../molecules";
 import styles from "./RecentViewSection.module.css";
 

--- a/src/components/organisms/ReviewsSection/ReviewsSection.tsx
+++ b/src/components/organisms/ReviewsSection/ReviewsSection.tsx
@@ -1,4 +1,4 @@
-import type { Review } from "../../../types";
+import type { Review } from "../../../types/types";
 import { ReviewableItem, ReviewItem } from "../../molecules";
 import styles from "./ReviewsSection.module.css";
 

--- a/src/components/organisms/WishListSection/WishListSection.tsx
+++ b/src/components/organisms/WishListSection/WishListSection.tsx
@@ -1,5 +1,5 @@
 import { Heart, Trash } from "lucide-react";
-import type { Product } from "../../../types";
+import type { Product } from "../../../types/products";
 import { EmptyState, ProductCard } from "../../molecules";
 import styles from "./WishListSection.module.css";
 

--- a/src/components/templates/ShopTemplate/ShopTemplate.tsx
+++ b/src/components/templates/ShopTemplate/ShopTemplate.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { useParams } from "react-router-dom";
+import { useState, useEffect } from "react";
+import { useParams, useSearchParams, useNavigate } from "react-router-dom";
 import { CATEGORIES } from "../../../constants/categories";
 import { Breadcrumb } from "../../molecules";
 import { SidebarFilters } from "../../organisms";
@@ -8,6 +8,25 @@ import styles from "./ShopTemplate.module.css";
 type ShopTemplateProps = {
   children: React.ReactNode;
 };
+
+// 영어 라벨 → DB 한글명 매핑 (임시)
+const BRAND_EN_TO_DB: Record<string, string> = {
+  NIKE: "나이키",
+  ADIDAS: "아디다스",
+  Reebok: "리복",
+  Vans: "반스",
+  Umbro: "엄브로",
+  Converse: "컨버스",
+  Puma: "푸마",
+  Hoka: "호카",
+  SHOOPEN: "슈펜",
+  ELCANTO: "엘칸토",
+  MLB: "엠엘비",
+};
+// 역매핑: DB 한글명 → 영어 라벨 (임시)
+const BRAND_DB_TO_EN: Record<string, string> = Object.fromEntries(
+  Object.entries(BRAND_EN_TO_DB).map(([en, ko]) => [ko, en]),
+);
 
 export default function ShopTemplate({ children }: ShopTemplateProps) {
   const { cat } = useParams<{ cat: string }>();
@@ -19,18 +38,81 @@ export default function ShopTemplate({ children }: ShopTemplateProps) {
   ]);
   const [priceRange, setPriceRange] = useState<[number, number]>([0, 1000000]);
 
+  const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+
+  // 1) 최초 진입 시: URL → 상태 복원 (안전)
+  useEffect(() => {
+    // brand 복원 (URL은 한글, 내부 상태는 영어 라벨)
+    const initialBrandsKo = searchParams.getAll("brand");
+    if (initialBrandsKo.length) {
+      const initialBrandsEn = initialBrandsKo.map(
+        (ko) => BRAND_DB_TO_EN[ko] ?? ko,
+      );
+      setSelectedBrands(initialBrandsEn);
+    }
+
+    // price 복원
+    const min = searchParams.get("minPrice");
+    const max = searchParams.get("maxPrice");
+    if (min || max) {
+      setPriceRange([min ? Number(min) : 0, max ? Number(max) : 1000000]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // 최초 1회만
+
+  // 2) 상태 → URL 동기화 (렌더 단계가 아닌 effect에서만 수행)
+  useEffect(() => {
+    const params = new URLSearchParams(searchParams);
+
+    // brand 재작성 (영→한 변환 후 URL에 기록)
+    params.delete("brand");
+    selectedBrands.forEach((en) => {
+      const ko = BRAND_EN_TO_DB[en] ?? en;
+      params.append("brand", ko);
+    });
+
+    // price 재작성
+    const [min, max] = priceRange;
+    if (min > 0) params.set("minPrice", String(min));
+    else params.delete("minPrice");
+
+    if (max < 1000000) params.set("maxPrice", String(max));
+    else params.delete("maxPrice");
+
+    // 필터 변경 시 커서 초기화
+    params.delete("cursor");
+
+    // 렌더 중이 아닌 effect에서만 라우터 상태 업데이트 → 경고 해결
+    setSearchParams(params);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedBrands, priceRange]);
+
+  // 3) 핸들러: 상태만 변경 (URL 갱신은 위 effect가 담당)
   const handleBrandToggle = (brand: string) => {
     setSelectedBrands((prev) =>
       prev.includes(brand) ? prev.filter((b) => b !== brand) : [...prev, brand],
     );
   };
 
+  useEffect(() => {
+    // 라우트 파라미터(:cat)가 바뀌면 사이드바 카테고리도 맞춰 갱신
+    setSelectedCategories([category.name]);
+  }, [category.name]);
+
   const handleCategoryToggle = (catName: string) => {
-    setSelectedCategories((prev) =>
-      prev.includes(catName)
-        ? prev.filter((c) => c !== catName)
-        : [...prev, catName],
-    );
+    const next = CATEGORIES.find((c) => c.name === catName);
+    if (!next) return;
+
+    // 현재 쿼리 유지하며 카테고리만 이동
+    navigate(`/category/${next.id}?${searchParams.toString()}`);
+
+    // UI 표시용 선택 상태
+    setSelectedCategories([catName]);
+  };
+
+  const handlePriceChange = (range: [number, number]) => {
+    setPriceRange(range);
   };
 
   return (
@@ -41,16 +123,16 @@ export default function ShopTemplate({ children }: ShopTemplateProps) {
         <SidebarFilters
           brands={[
             "NIKE",
-            "ZARA",
-            "H&M",
-            "INNISFREE",
-            "COS",
-            "LANEIGE",
-            "MANGO",
-            "CONVERSE",
-            "MULBERRY",
-            "SK-II",
             "ADIDAS",
+            "Reebok",
+            "Vans",
+            "Umbro",
+            "Converse",
+            "Puma",
+            "Hoka",
+            "SHOOPEN",
+            "ELCANTO",
+            "MLB",
           ]}
           categories={CATEGORIES.map((c) => c.name)}
           selectedBrands={selectedBrands}
@@ -58,7 +140,7 @@ export default function ShopTemplate({ children }: ShopTemplateProps) {
           priceRange={priceRange}
           onBrandToggle={handleBrandToggle}
           onCategoryToggle={handleCategoryToggle}
-          onPriceChange={setPriceRange}
+          onPriceChange={handlePriceChange}
         />
         <div className={styles.main}>{children}</div>
       </div>

--- a/src/components/templates/ShopTemplate/ShopTemplate.tsx
+++ b/src/components/templates/ShopTemplate/ShopTemplate.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from "react";
-import { useParams, useSearchParams, useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { CATEGORIES } from "../../../constants/categories";
 import { Breadcrumb } from "../../molecules";
 import { SidebarFilters } from "../../organisms";
@@ -59,11 +59,11 @@ export default function ShopTemplate({ children }: ShopTemplateProps) {
       setPriceRange([min ? Number(min) : 0, max ? Number(max) : 1000000]);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // 최초 1회만
+  }, [searchParams]); // 최초 1회만
 
   // 2) 상태 → URL 동기화 (렌더 단계가 아닌 effect에서만 수행)
   useEffect(() => {
-    const params = new URLSearchParams(searchParams);
+    const params = new URLSearchParams();
 
     // brand 재작성 (영→한 변환 후 URL에 기록)
     params.delete("brand");
@@ -84,9 +84,9 @@ export default function ShopTemplate({ children }: ShopTemplateProps) {
     params.delete("cursor");
 
     // 렌더 중이 아닌 effect에서만 라우터 상태 업데이트 → 경고 해결
-    setSearchParams(params);
+    setSearchParams(params, { replace: true });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedBrands, priceRange]);
+  }, [selectedBrands, priceRange, setSearchParams]);
 
   // 3) 핸들러: 상태만 변경 (URL 갱신은 위 effect가 담당)
   const handleBrandToggle = (brand: string) => {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, type ReactNode, useContext, useState } from "react";
-import type { User } from "../types";
+import type { User } from "../types/types";
 
 type AuthState = {
   isLoggedIn: boolean;

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,0 +1,24 @@
+import axios from "axios";
+
+export const api = axios.create({
+  baseURL: "/api",
+});
+
+// api.interceptors.request.use((config) => {
+//   const token = localStorage.getItem("accessToken");
+//   if (token) config.headers.Authorization = `Bearer ${token}`;
+//   return config;
+// });
+
+// api.interceptors.response.use(
+//   (res) => res,
+//   (error) => {
+//     const status = error.response?.status;
+//     if (status === 401) {
+//       localStorage.removeItem("accessToken");
+//       // TODO: 전역 토스트/스낵바
+//       window.location.href = "/login";
+//     }
+//     return Promise.reject(error);
+//   },
+// );

--- a/src/pages/Category/Category.tsx
+++ b/src/pages/Category/Category.tsx
@@ -1,125 +1,124 @@
-import { useParams } from "react-router-dom";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useParams, useSearchParams } from "react-router-dom";
+import { listProducts } from "../../api/products"; // API 호출 함수
 import { ProductSection } from "../../components/organisms";
 import { ShopTemplate } from "../../components/templates";
 import { CATEGORIES } from "../../constants/categories";
-import type { Product } from "../../types";
+import type { Product } from "../../types/products";
 
-const newProducts: Product[] = [
-  {
-    id: 1,
-    brand: "NIKE",
-    name: "에어맥스 270 스니커즈",
-    price: 159000,
-    originalPrice: 189000,
-    discount: 16,
-    category: "shoes",
-    image:
-      "https://readdy.ai/api/search-image?query=modern%20white%20sneakers%20on%20clean%20white%20background%20minimalist%20product%20photography%20studio%20lighting%20professional%20commercial%20style&width=400&height=400&seq=product1&orientation=squarish",
-  },
-  {
-    id: 2,
-    brand: "ZARA",
-    name: "오버사이즈 블레이저",
-    price: 89000,
-    originalPrice: 119000,
-    discount: 25,
-    category: "outerwear",
-    image:
-      "https://readdy.ai/api/search-image?query=elegant%20black%20blazer%20jacket%20on%20white%20background%20minimalist%20fashion%20photography%20studio%20lighting%20professional%20commercial%20style&width=400&height=400&seq=product2&orientation=squarish",
-  },
-  {
-    id: 3,
-    brand: "H&M",
-    name: "코튼 와이드 팬츠",
-    price: 39000,
-    originalPrice: 49000,
-    discount: 20,
-    category: "pants",
-    image:
-      "https://readdy.ai/api/search-image?query=beige%20wide%20leg%20pants%20on%20white%20background%20minimalist%20fashion%20photography%20studio%20lighting%20professional%20commercial%20style&width=400&height=400&seq=product3&orientation=squarish",
-  },
-  {
-    id: 9,
-    brand: "INNISFREE",
-    name: "그린티 세럼",
-    price: 28000,
-    originalPrice: 35000,
-    discount: 20,
-    category: "beauty",
-    image:
-      "https://readdy.ai/api/search-image?query=green%20tea%20serum%20in%20transparent%20bottle%20on%20white%20background%20minimalist%20beauty%20product%20photography%20studio%20lighting%20professional%20commercial%20style&width=400&height=400&seq=product9&orientation=squarish",
-  },
-  {
-    id: 12,
-    brand: "COS",
-    name: "오가닉 코튼 티셔츠",
-    price: 29000,
-    category: "tops",
-    image:
-      "https://readdy.ai/api/search-image?query=organic%20cotton%20t-shirt%20on%20white%20background%20minimalist%20fashion%20photography%20studio%20lighting%20professional%20commercial%20style&width=400&height=400&seq=product12&orientation=squarish",
-  },
-  {
-    id: 8,
-    brand: "LANEIGE",
-    name: "수분 크림",
-    price: 38000,
-    originalPrice: 42000,
-    discount: 10,
-    category: "beauty",
-    image:
-      "https://readdy.ai/api/search-image?query=luxury%20moisturizing%20cream%20in%20elegant%20glass%20jar%20on%20clean%20white%20background%20minimalist%20beauty%20product%20photography%20studio%20lighting%20professional%20commercial%20style&width=400&height=400&seq=product8&orientation=squarish",
-  },
-
-  {
-    id: 13,
-    brand: "MANGO",
-    name: "리넨 셔츠",
-    price: 45000,
-    category: "tops",
-    image:
-      "https://readdy.ai/api/search-image?query=light%20linen%20shirt%20on%20white%20background%20minimalist%20fashion%20photography%20studio%20lighting%20professional%20commercial%20style&width=400&height=400&seq=product13&orientation=squarish",
-  },
-  {
-    id: 14,
-    brand: "CONVERSE",
-    name: "척 테일러 올스타",
-    price: 79000,
-    category: "shoes",
-    image:
-      "https://readdy.ai/api/search-image?query=classic%20white%20canvas%20sneakers%20on%20white%20background%20minimalist%20product%20photography%20studio%20lighting%20professional%20commercial%20style&width=400&height=400&seq=product14&orientation=squarish",
-  },
-  {
-    id: 15,
-    brand: "MULBERRY",
-    name: "베이시스 백",
-    price: 450000,
-    category: "bags",
-    image:
-      "https://readdy.ai/api/search-image?query=luxury%20brown%20leather%20handbag%20on%20white%20background%20minimalist%20fashion%20photography%20studio%20lighting%20professional%20commercial%20style&width=400&height=400&seq=product15&orientation=squarish",
-  },
-  {
-    id: 16,
-    brand: "SK-II",
-    name: "페이셜 트리트먼트 에센스",
-    price: 150000,
-    category: "beauty",
-    image:
-      "https://readdy.ai/api/search-image?query=luxury%20facial%20essence%20bottle%20on%20white%20background%20minimalist%20beauty%20product%20photography%20studio%20lighting%20professional%20commercial%20style&width=400&height=400&seq=product16&orientation=squarish",
-  },
-  {
-    id: 17,
-    brand: "ADIDAS",
-    name: "스탠 스미스 스니커즈",
-    price: 119000,
-    category: "shoes",
-    image:
-      "https://readdy.ai/api/search-image?query=classic%20white%20leather%20sneakers%20on%20white%20background%20minimalist%20product%20photography%20studio%20lighting%20professional%20commercial%20style&width=400&height=400&seq=product17&orientation=squarish",
-  },
-];
-
-const Category = () => {
+const Category: React.FC = () => {
   const { cat } = useParams<{ cat: string }>();
   const category = CATEGORIES.find((c) => c.id === cat) ?? CATEGORIES[0];
+
+  const [searchParams] = useSearchParams(); // ShopTemplate가 기록한 쿼리 읽기
+  const brands = useMemo(() => searchParams.getAll("brand"), [searchParams]); // 쿼리 읽은 후에 &brand=... 반복 파라미터
+  const brandsKey = brands.join("|");
+  const minPrice = searchParams.get("minPrice")
+    ? Number(searchParams.get("minPrice"))
+    : undefined; // [ADD]
+  const maxPrice = searchParams.get("maxPrice")
+    ? Number(searchParams.get("maxPrice"))
+    : undefined; // [ADD]
+
+  // 서버 데이터/상태
+  const [products, setProducts] = useState<Product[]>([]);
+  const [nextCursor, setNextCursor] = useState<number | null>(null);
+  const [hasNext, setHasNext] = useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // 👇 무한 스크롤용 센티넬
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  // 첫 로드 & 카테고리 변경 시 조회
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <Infinite loop>
+  useEffect(() => {
+    let ignore = false;
+    async function fetchFirst() {
+      try {
+        setLoading(true);
+        setError(null);
+        const data = await listProducts({
+          category: category.id, // 백엔드 카테고리 슬러그
+          size: 12,
+          brand: brands.length ? brands : undefined, // 브랜드 필터 전파
+          minPrice,
+          maxPrice,
+        });
+        if (ignore) return;
+        setProducts(data.products);
+        setNextCursor(data.nextCursor);
+        setHasNext(data.hasNext);
+      } catch (error: unknown) {
+        if (!ignore) {
+          setError(`${error}`);
+        }
+      } finally {
+        if (!ignore) setLoading(false);
+      }
+    }
+    fetchFirst();
+    return () => {
+      ignore = true;
+    };
+  }, [category.id, brandsKey, minPrice, maxPrice, brands]); // 필터 변경 시 재조회
+
+  // 다음 페이지 로드 (커서 기반)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <Infinite loop>
+  const loadMore = useCallback(async () => {
+    if (!hasNext || loading) return;
+    try {
+      setLoading(true);
+      const data = await listProducts({
+        category: category.id,
+        size: 12,
+        cursor: nextCursor ?? undefined,
+        brand: brands.length ? brands : undefined, // [ADD] 다음 페이지에도 동일 필터 전달
+        minPrice, // [ADD]
+        maxPrice, // [ADD]
+      });
+      setProducts((prev) => [...prev, ...data.products]);
+      setNextCursor(data.nextCursor);
+      setHasNext(data.hasNext);
+    } catch (error: unknown) {
+      setError(`${error}`);
+    } finally {
+      setLoading(false);
+    }
+  }, [
+    category.id,
+    hasNext,
+    loading,
+    nextCursor,
+    brandsKey,
+    minPrice,
+    maxPrice,
+  ]);
+
+  // IntersectionObserver로 무한 스크롤
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el || !hasNext) return;
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        const first = entries[0];
+        if (first.isIntersecting && !loading) {
+          loadMore();
+        }
+      },
+      {
+        root: null, // 뷰포트 기준
+        rootMargin: "200px", // 200px 남았을 때 미리 로드
+        threshold: 0,
+      },
+    );
+
+    io.observe(el);
+    return () => {
+      io.disconnect();
+    };
+  }, [hasNext, loading, loadMore]);
 
   return (
     <div>
@@ -127,9 +126,14 @@ const Category = () => {
         <ProductSection
           title={category.name}
           numberOfProducts={true}
-          products={newProducts}
+          products={products} // 서버에서 받은 목록
           selectedCategory={category.id}
+          disableFiltering={true} // 서버에서 이미 카테고리 필터링했으니 중복 필터 X
         />
+        <div ref={sentinelRef} style={{ height: 1 }} />
+        {error && ( // ← 이 부분이 추가됨
+          <div className="error-message">{error}</div>
+        )}
       </ShopTemplate>
     </div>
   );

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,171 +1,44 @@
+import type React from "react";
+import { useEffect, useState } from "react";
+import { getBestProducts, getNewProducts } from "../../api/mainProducts";
 import { HeroSection, ProductSection } from "../../components/organisms";
 import { useCategory } from "../../contexts/CategoryContext";
-import type { Product } from "../../types";
+import type { Product } from "../../types/products";
 import styles from "./Home.module.css";
 
-const newProducts: Product[] = [
-  {
-    id: 1,
-    brand: "NIKE",
-    name: "에어맥스 270 스니커즈",
-    price: 159000,
-    originalPrice: 189000,
-    discount: 16,
-    category: "신발",
-    image:
-      "https://readdy.ai/api/search-image?query=modern%20white%20sneakers%20on%20clean%20white%20background%20minimalist%20product%20photography%20studio%20lighting%20professional%20commercial%20style&width=400&height=400&seq=product1&orientation=squarish",
-  },
-  {
-    id: 2,
-    brand: "ZARA",
-    name: "오버사이즈 블레이저",
-    price: 89000,
-    originalPrice: 119000,
-    discount: 25,
-    category: "아우터",
-    image:
-      "https://readdy.ai/api/search-image?query=elegant%20black%20blazer%20jacket%20on%20white%20background%20minimalist%20fashion%20photography%20studio%20lighting%20professional%20commercial%20style&width=400&height=400&seq=product2&orientation=squarish",
-  },
-  {
-    id: 3,
-    brand: "H&M",
-    name: "코튼 와이드 팬츠",
-    price: 39000,
-    originalPrice: 49000,
-    discount: 20,
-    category: "바지",
-    image:
-      "https://readdy.ai/api/search-image?query=beige%20wide%20leg%20pants%20on%20white%20background%20minimalist%20fashion%20photography%20studio%20lighting%20professional%20commercial%20style&width=400&height=400&seq=product3&orientation=squarish",
-  },
-  {
-    id: 9,
-    brand: "INNISFREE",
-    name: "그린티 세럼",
-    price: 28000,
-    originalPrice: 35000,
-    discount: 20,
-    category: "뷰티",
-    image:
-      "https://readdy.ai/api/search-image?query=green%20tea%20serum%20in%20transparent%20bottle%20on%20white%20background%20minimalist%20beauty%20product%20photography%20studio%20lighting%20professional%20commercial%20style&width=400&height=400&seq=product9&orientation=squarish",
-  },
-  {
-    id: 12,
-    brand: "COS",
-    name: "오가닉 코튼 티셔츠",
-    price: 29000,
-    category: "상의",
-    image:
-      "https://readdy.ai/api/search-image?query=organic%20cotton%20t-shirt%20on%20white%20background%20minimalist%20fashion%20photography%20studio%20lighting%20professional%20commercial%20style&width=400&height=400&seq=product12&orientation=squarish",
-  },
-  {
-    id: 8,
-    brand: "LANEIGE",
-    name: "수분 크림",
-    price: 38000,
-    originalPrice: 42000,
-    discount: 10,
-    category: "뷰티",
-    image:
-      "https://readdy.ai/api/search-image?query=luxury%20moisturizing%20cream%20in%20elegant%20glass%20jar%20on%20clean%20white%20background%20minimalist%20beauty%20product%20photography%20studio%20lighting%20professional%20commercial%20style&width=400&height=400&seq=product8&orientation=squarish",
-  },
-
-  {
-    id: 13,
-    brand: "MANGO",
-    name: "리넨 셔츠",
-    price: 45000,
-    category: "상의",
-    image:
-      "https://readdy.ai/api/search-image?query=light%20linen%20shirt%20on%20white%20background%20minimalist%20fashion%20photography%20studio%20lighting%20professional%20commercial%20style&width=400&height=400&seq=product13&orientation=squarish",
-  },
-  {
-    id: 14,
-    brand: "CONVERSE",
-    name: "척 테일러 올스타",
-    price: 79000,
-    category: "신발",
-    image:
-      "https://readdy.ai/api/search-image?query=classic%20white%20canvas%20sneakers%20on%20white%20background%20minimalist%20product%20photography%20studio%20lighting%20professional%20commercial%20style&width=400&height=400&seq=product14&orientation=squarish",
-  },
-  {
-    id: 15,
-    brand: "MULBERRY",
-    name: "베이시스 백",
-    price: 450000,
-    category: "가방",
-    image:
-      "https://readdy.ai/api/search-image?query=luxury%20brown%20leather%20handbag%20on%20white%20background%20minimalist%20fashion%20photography%20studio%20lighting%20professional%20commercial%20style&width=400&height=400&seq=product15&orientation=squarish",
-  },
-  {
-    id: 16,
-    brand: "SK-II",
-    name: "페이셜 트리트먼트 에센스",
-    price: 150000,
-    category: "뷰티",
-    image:
-      "https://readdy.ai/api/search-image?query=luxury%20facial%20essence%20bottle%20on%20white%20background%20minimalist%20beauty%20product%20photography%20studio%20lighting%20professional%20commercial%20style&width=400&height=400&seq=product16&orientation=squarish",
-  },
-];
-
-const bestProducts: Product[] = [
-  {
-    id: 4,
-    brand: "UNIQLO",
-    name: "히트텍 크루넥 긴팔티",
-    price: 19900,
-    category: "상의",
-    image:
-      "https://readdy.ai/api/search-image?query=black%20long%20sleeve%20t-shirt%20on%20white%20background%20minimalist%20fashion%20photography%20studio%20lighting%20professional%20commercial%20style&width=400&height=400&seq=product4&orientation=squarish",
-  },
-  {
-    id: 5,
-    brand: "ADIDAS",
-    name: "스탠 스미스 스니커즈",
-    price: 109000,
-    category: "신발",
-    image:
-      "https://readdy.ai/api/search-image?query=white%20leather%20sneakers%20on%20clean%20white%20background%20minimalist%20product%20photography%20studio%20lighting%20professional%20commercial%20style&width=400&height=400&seq=product5&orientation=squarish",
-  },
-  {
-    id: 6,
-    brand: "ZARA",
-    name: "미니 크로스백",
-    price: 59000,
-    category: "가방",
-    image:
-      "https://readdy.ai/api/search-image?query=small%20black%20leather%20crossbody%20bag%20on%20white%20background%20minimalist%20fashion%20photography%20studio%20lighting%20professional%20commercial%20style&width=400&height=400&seq=product6&orientation=squarish",
-  },
-  {
-    id: 7,
-    brand: "H&M",
-    name: "니트 원피스",
-    price: 49000,
-    category: "원피스/스커트",
-    image:
-      "https://readdy.ai/api/search-image?query=beige%20knit%20dress%20on%20white%20background%20minimalist%20fashion%20photography%20studio%20lighting%20professional%20commercial%20style&width=400&height=400&seq=product7&orientation=squarish",
-  },
-  {
-    id: 10,
-    brand: "SULWHASOO",
-    name: "윤조에센스",
-    price: 120000,
-    category: "뷰티",
-    image:
-      "https://readdy.ai/api/search-image?query=luxury%20golden%20essence%20bottle%20on%20marble%20background%20minimalist%20beauty%20product%20photography%20studio%20lighting%20professional%20commercial%20style&width=400&height=400&seq=product10&orientation=squarish",
-  },
-  {
-    id: 11,
-    brand: "MAC",
-    name: "레트로 매트 립스틱",
-    price: 32000,
-    category: "뷰티",
-    image:
-      "https://readdy.ai/api/search-image?query=elegant%20red%20lipstick%20on%20black%20glossy%20surface%20minimalist%20beauty%20product%20photography%20studio%20lighting%20professional%20commercial%20style&width=400&height=400&seq=product11&orientation=squarish",
-  },
-];
-
-const Home = () => {
+const Home: React.FC = () => {
   const { selected } = useCategory();
+  const [newProducts, setNewProducts] = useState<Product[]>([]);
+  const [bestProducts, setBestProducts] = useState<Product[]>([]); // (옵션)
+
+  useEffect(() => {
+    // 신상품 조회
+    const fetchNewProducts = async () => {
+      try {
+        const products = await getNewProducts();
+        setNewProducts(products);
+      } catch (error: unknown) {
+        const errorMessage =
+          error instanceof Error ? error.message : "상품 목록 조회 실패";
+        console.error("상품 목록 조회 실패:", errorMessage);
+      }
+    };
+
+    // 베스트 상품 조회
+    const fetchBestProducts = async () => {
+      try {
+        const products = await getBestProducts();
+        setBestProducts(products);
+      } catch (error: unknown) {
+        const errorMessage =
+          error instanceof Error ? error.message : "베스트 상품 조회 실패";
+        console.error("베스트 상품 조회 실패:", errorMessage);
+      }
+    };
+
+    fetchNewProducts();
+    fetchBestProducts();
+  }, []);
 
   return (
     <div className={styles.container}>

--- a/src/types/products.ts
+++ b/src/types/products.ts
@@ -1,0 +1,27 @@
+export type Product = {
+  id: number;
+  brand: string;
+  name: string;
+  price: number;
+  originalPrice?: number;
+  discount?: number;
+  category: string;
+  image: string;
+};
+
+// 2) 요청/응답 타입
+export type ListProductsParams = {
+  category: string; // 필수: 카테고리 슬러그 (e.g. 'shoes')
+  brand?: string[]; // &brand=나이키&brand=반스
+  minPrice?: number;
+  maxPrice?: number;
+  sort?: "recommend" | "popular" | "new" | "priceAsc" | "priceDesc";
+  cursor?: number; // 이전 응답의 nextCursor
+  size?: number; // 페이지 크기(기본 12)
+};
+
+export type ListProductsData = {
+  products: Product[];
+  nextCursor: number | null;
+  hasNext: boolean;
+};

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,14 +1,3 @@
-export type Product = {
-  id: number;
-  brand: string;
-  name: string;
-  price: number;
-  originalPrice?: number;
-  discount?: number;
-  category: string;
-  image: string;
-};
-
 export type Message = {
   id: number;
   text: string;


### PR DESCRIPTION
[작업한 내용]
- 메인 페이지 상품 목록 조회 구현
- 카테고리별/정렬/필터 상품 조회 (무한 스크롤 기반) 구현

[참고사항]
- 임시 매핑한 것 브랜드 데이터 전부 들어오고 나면 삭제하고 새로운 api구현 예정
- 상품 개수 api 추후에 제작 후 적용 예정
