### PR TITLE
Feat: JWT 토큰 자동 재발급 및 연장 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@radix-ui/themes": "^3.2.1",
         "axios": "^1.11.0",
         "classnames": "^2.5.1",
+        "jwt-decode": "^4.0.0",
         "lucide-react": "^0.525.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -3116,6 +3117,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/lucide-react": {
       "version": "0.525.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.525.0.tgz",
@@ -3658,21 +3668,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/themes": "^3.2.1",
     "axios": "^1.11.0",
     "classnames": "^2.5.1",
+    "jwt-decode": "^4.0.0",
     "lucide-react": "^0.525.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { AuthProvider } from "./contexts/AuthContext";
 import { CategoryProvider } from "./contexts/CategoryContext";
 import { ModalProvider } from "./contexts/ModalContext";
 import { ToastProvider } from "./contexts/ToastContext";
+import { useTokenExpirationCheck } from "./hooks/useTokenExpirationCheck";
 import {
   Cart,
   Category,
@@ -20,6 +21,11 @@ import {
   SignUp,
 } from "./pages";
 import type { Message } from "./types/types";
+
+function GlobalAppSetup() {
+  useTokenExpirationCheck();
+  return null;
+}
 
 export default function App() {
   const [isChatOpen, setIsChatOpen] = useState(false);
@@ -52,23 +58,21 @@ export default function App() {
         <AuthProvider>
           <CategoryProvider>
             <ModalProvider>
+              <GlobalAppSetup />
               <MainTemplate>
                 <Routes>
                   <Route path="/" element={<Home />} />
                   <Route path="/login" element={<Login />} />
                   <Route path="/signup" element={<SignUp />} />
                   <Route path="/find-password" element={<FindPassword />} />
-
                   <Route path="/category/:cat" element={<Category />} />
                   <Route path="/products/:id" element={<ProductDetail />} />
                   <Route
                     path="/products/:id/inquiry"
                     element={<ProductInquiry />}
                   />
-
                   <Route path="/cart" element={<Cart />} />
                   <Route path="/payment" element={<Payment />} />
-
                   <Route path="/mypage/:tab?" element={<Mypage />} />
                 </Routes>
 

--- a/src/api/authApi.ts
+++ b/src/api/authApi.ts
@@ -41,6 +41,11 @@ type LoginData = {
   accessToken: string;
 };
 
+// Access Token 재발급 성공 시 받을 데이터 타입
+type RefreshData = {
+  accessToken: string;
+};
+
 //  로그인 API 함수
 export async function login(body: LoginBody): Promise<LoginData> {
   const res = await api.post("/auth/login", body);
@@ -51,6 +56,13 @@ export async function login(body: LoginBody): Promise<LoginData> {
 export async function register(body: RegisterBody): Promise<ApiSuccessMessage> {
   const res = await api.post("/auth/register", body);
   return { message: res.data.message };
+}
+
+// HttpOnly 쿠키에 담긴 Refresh Token을 이용해 새 Access Token을 요청합니다.
+
+export async function refreshAccessToken(): Promise<RefreshData> {
+  const res = await api.post("/auth/refresh");
+  return res.data.data as RefreshData;
 }
 
 // 4. 비밀번호 찾기 1단계: 인증번호 요청

--- a/src/hooks/useTokenExpirationCheck.ts
+++ b/src/hooks/useTokenExpirationCheck.ts
@@ -1,0 +1,83 @@
+import { jwtDecode } from "jwt-decode";
+import { useCallback, useEffect, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+import { refreshAccessToken } from "../api/authApi";
+import { useModal } from "../contexts/ModalContext";
+
+const EXPIRATION_THRESHOLD = 10 * 60 * 1000;
+
+export function useTokenExpirationCheck() {
+  const { confirm } = useModal();
+  const navigate = useNavigate();
+  const isHandlingSession = useRef(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const forceLogout = useCallback(() => {
+    localStorage.removeItem("accessToken");
+    navigate("/login");
+  }, [navigate]);
+
+  const handleSession = useCallback(async () => {
+    if (isHandlingSession.current) return;
+    isHandlingSession.current = true;
+
+    const shouldExtend = await confirm({
+      title: "로그인 연장",
+      description: "세션이 곧 만료됩니다. 로그인을 30분 연장하시겠습니까?",
+      confirmText: "연장",
+      cancelText: "취소",
+    });
+
+    if (shouldExtend) {
+      try {
+        const { accessToken: newAccessToken } = await refreshAccessToken();
+        localStorage.setItem("accessToken", newAccessToken);
+      } catch (error) {
+        console.error("세션 연장 실패:", error);
+        alert("세션이 만료되었습니다. 다시 로그인해주세요.");
+        forceLogout();
+      }
+    } else {
+      forceLogout();
+    }
+
+    isHandlingSession.current = false;
+  }, [confirm, forceLogout]);
+
+  useEffect(() => {
+    const checkToken = () => {
+      const accessToken = localStorage.getItem("accessToken");
+      if (!accessToken) {
+        if (intervalRef.current) clearInterval(intervalRef.current);
+        return;
+      }
+
+      try {
+        const decodedToken = jwtDecode<{ exp: number }>(accessToken);
+        const timeRemaining = decodedToken.exp * 1000 - Date.now();
+
+        if (timeRemaining <= 0) {
+          alert("세션이 만료되어 자동으로 로그아웃됩니다.");
+          forceLogout();
+          if (intervalRef.current) clearInterval(intervalRef.current);
+          return;
+        }
+
+        if (timeRemaining < EXPIRATION_THRESHOLD) {
+          handleSession();
+        }
+      } catch (error) {
+        console.error("유효하지 않은 토큰:", error);
+        forceLogout();
+        if (intervalRef.current) clearInterval(intervalRef.current);
+      }
+    };
+
+    const intervalId = setInterval(checkToken, 30 * 1000);
+    intervalRef.current = intervalId;
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [handleSession, forceLogout]);
+}

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,23 +1,46 @@
 import axios from "axios";
+import { refreshAccessToken } from "../api/authApi";
 
+// 1. API 요청을 위한 기본 Axios 인스턴스 생성
 export const api = axios.create({
   baseURL: "/api",
+  withCredentials: true,
 });
 
+// 2. 요청 인터셉터 (API 요청을 보내기 전에 실행)
 api.interceptors.request.use(
   (config) => {
-    // localStorage에서 accessToken을 가져옵니다.
     const accessToken = localStorage.getItem("accessToken");
-
-    // 토큰이 존재하면, 모든 요청 헤더에 Authorization을 추가합니다.
     if (accessToken) {
       config.headers.Authorization = `Bearer ${accessToken}`;
     }
-
     return config;
   },
   (error) => {
-    // 요청 에러 처리
+    return Promise.reject(error);
+  },
+);
+
+// 3. 응답 인터셉터 (API 응답을 받은 후에 실행)
+api.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+
+      try {
+        const { accessToken: newAccessToken } = await refreshAccessToken();
+        localStorage.setItem("accessToken", newAccessToken);
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+        return api(originalRequest);
+      } catch (refreshError) {
+        localStorage.removeItem("accessToken");
+        window.location.href = "/login";
+        return Promise.reject(refreshError);
+      }
+    }
     return Promise.reject(error);
   },
 );


### PR DESCRIPTION
[작업한 내용]

- Refresh Token으로 Access Token을 자동 재발급하고 원래 요청을 재시도하는 기능을 구현
- useTokenExpirationCheck 커스텀 훅을 생성하여 Access Token 만료 10분 전에 사용자에게 세션 연장 여부를 묻는 모달을 띄우는 기능 추가
- 토큰 재발급을 위한 refreshAccessToken API 함수를 추가하고, 토큰 정보 확인을 위해 jwt-decode 라이브러리 설치

[참고사항]

- Access Token은 localStorage에, Refresh Token은 HttpOnly 쿠키를 통해 관리됩니다.
